### PR TITLE
sort words in true dictionary order

### DIFF
--- a/printers/printer.php
+++ b/printers/printer.php
@@ -14,6 +14,7 @@ abstract class nspages_printer {
     private $pos;
     private $actualTitleLevel;
     private $natOrder;
+    private $dictOrder;
     private $nbItemsMax;
 
     function __construct($plugin, $mode, $renderer, $data){
@@ -22,6 +23,7 @@ abstract class nspages_printer {
       $this->mode = $mode;
       $this->pos = $data['pos'];
       $this->natOrder = $data['natOrder'];
+      $this->dictOrder = $data['dictOrder'];
       $this->actualTitleLevel = $data['actualTitleLevel'];
       $this->nbItemsMax = $data['nbItemsMax'];
     }
@@ -76,6 +78,11 @@ abstract class nspages_printer {
     private function _sort(&$tab, $reverse) {
         if ( $this->natOrder ){
             usort($tab, array("nspages_printer", "_natOrder"));
+        } else if ($this->dictOrder) {
+            $oldLocale=setlocale(LC_ALL, 0);
+            setlocale(LC_COLLATE, 'sk_SK.utf8');
+            usort($tab, array("nspages_printer", "_dictOrder"));
+            setlocale(LC_COLLATE, $oldLocale);
         } else {
             usort($tab, array("nspages_printer", "_order"));
         }
@@ -91,6 +98,10 @@ abstract class nspages_printer {
     private static function _natOrder($p1, $p2) {
         return strnatcasecmp($p1['sort'], $p2['sort']);
     }
+
+    private static function _dictOrder($p1, $p2) {
+        return strcoll($p1['sort'], $p2['sort']);
+    }    
 
     private function _keepOnlyNMaxItems(&$tab){
         if ($this->nbItemsMax){

--- a/syntax.php
+++ b/syntax.php
@@ -57,6 +57,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         optionParser::checkOption($match, "reverse", $return['reverse'], true);
         optionParser::checkOption($match, "pagesinns", $return['pagesinns'], true);
         optionParser::checkOption($match, "nat(ural)?Order", $return['natOrder'], true);
+        optionParser::checkOption($match, "dict(ionary)?Order", $return['dictOrder'], true);
         optionParser::checkOption($match, "sort(By)?Date", $return['sortDate'], true);
         optionParser::checkOption($match, "sort(By)?CreationDate", $return['sortByCreationDate'], true);
         optionParser::checkOption($match, "hidenopages", $return['hidenopages'], true);
@@ -108,7 +109,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
             'idAndTitle'    => false, 'nbItemsMax' => 0, 'numberedList' => false,
             'natOrder'      => false, 'sortDate' => false,
             'hidenopages'   => false, 'hidenosubns' => false, 'usePictures' => false,
-            'showhidden'    => false,
+            'showhidden'    => false, 'dictOrder' => false,
             'modificationDateOnPictures' => false,
             'sortByCreationDate' => false, 'defaultPicture' => null,
         );


### PR DESCRIPTION
Accented words are not sorted in dictionary order.
I've added a quick dictionary order support (with a new -dictionaryOrder option)